### PR TITLE
feat: display resources in reverse chronological order

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -69,7 +69,7 @@ module.exports = function (config) {
 
     config.addCollection("resources", collection => {
         return [
-            ...collection.getFilteredByGlob("./src/resources/*.md").filter(liveResources)
+            ...collection.getFilteredByGlob("./src/resources/*.md").filter(liveResources).reverse()
         ];
     });
 


### PR DESCRIPTION
Hi @sepidehshahi, this PR changes the resources page to show resources in reverse chronological order with the newest ones at the top.